### PR TITLE
add feature: filter

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -11,14 +11,20 @@
 
 #include <string.h>
 #include <glib.h>
+#include <regex.h>
+#include <sys/types.h>
 
 #include "srv_session.h"
 
 #include "meta.h"
 #include "log.h"
+#include "filter.h"
 
 GList *ignore_list;
 GList *relaybot_list;
+GList *filter_list;
+
+int disable_filter = 0; //TODO: Add filter_disable/enable
 
 typedef struct {
     char ldelim[10];
@@ -133,7 +139,7 @@ int filter_ignore_list_rm(const char *nick){
     lst = ignore_list;
     while (lst){
         if (strncmp(lst->data, nick, NICK_LEN) == 0){
-            free(lst->data);
+            g_free(lst->data);
             ignore_list = g_list_remove(ignore_list, lst->data);
 
             LOG_FR("Remove %s", nick);
@@ -146,7 +152,7 @@ int filter_ignore_list_rm(const char *nick){
     return -1;
 }
 
-int filter_relaybot_list_add(const char *nick, char *ldelim, char* rdelim){
+int filter_relaybot_list_add(const char *nick, const char *ldelim, const char* rdelim){
     GList *lst;
     RelaybotInfo *info;
 
@@ -154,13 +160,13 @@ int filter_relaybot_list_add(const char *nick, char *ldelim, char* rdelim){
     while (lst){
         info = lst->data;
         if (strncmp(info->nick, nick, NICK_LEN) == 0){
-            WARN_FR("%s already exist in relaybot_list", nick);
+            WARN_FR("%s already exists in relaybot_list", nick);
             return -1;
         }
         lst = lst->next;
     }
 
-    info = calloc(1, sizeof(RelaybotInfo));
+    info = g_malloc0(sizeof(RelaybotInfo));
     strncpy(info->nick, nick, NICK_LEN);
     strncpy(info->ldelim, ldelim, 10);
     strncpy(info->rdelim, rdelim, 10);
@@ -179,7 +185,7 @@ int filter_relaybot_list_rm(const char *nick){
     while (lst){
         info = lst->data;
         if (strncmp(info->nick, nick, NICK_LEN) == 0){
-            free(lst->data);
+            g_free(lst->data);
             relaybot_list = g_list_remove(relaybot_list, lst->data);
             LOG_FR("Remove %s", nick);
 
@@ -190,4 +196,128 @@ int filter_relaybot_list_rm(const char *nick){
 
     WARN_FR("%s no found", nick);
     return -1;
+}
+
+int filter_filter_add_filter(
+        const char *name,
+        const char *regex,
+        const char *channel_name
+){
+    GList *lst = filter_list;
+    FilterItem *item;
+
+    while(lst){
+        item = lst->data;
+        if (strncmp(item->name, name, FILTER_NAME_MAX_LEN) == 0){
+            WARN_FR("%s already exists in filter_list", name);
+            return -1;
+        }
+        lst = lst->next;
+    }
+
+    item = g_malloc0(sizeof(FilterItem));
+    if (item == 0){
+        ERR_FR("The memory is exhausted");
+        return -1;
+    }
+
+    strncpy(item->name, name, FILTER_NAME_MAX_LEN);
+    strncpy(item->regex, regex, FILTER_MAX_LEN);
+    strncpy(item->channel_name, channel_name, CHAN_LEN);
+
+    filter_list = g_list_append(filter_list, item);
+    LOG_FR("Add filter %s, regex: '%s', channel: '%s'", name, regex, channel_name);
+
+    return 0;
+}
+
+int filter_filter_remove_filter(const char *filter_name) {
+    GList *lst = filter_list;
+    FilterItem *filter_item;
+    while(lst){
+        filter_item = lst->data;
+        if(strncmp(filter_name, filter_item->name, FILTER_MAX_LEN) == 0){
+            g_free(lst->data);
+            filter_list = g_list_remove(filter_list, lst->data);
+            LOG_FR("Remove filter %s", filter_name);
+
+            return 0;
+        }
+        lst = lst->next;
+    }
+    return -1;
+}
+
+int filter_filter_show(){
+    GList *lst = filter_list;
+    FilterItem *item;
+
+    while(lst){
+        item = lst->data;
+        //TODO: show all filters on the current buffer
+        lst = lst->next;
+    }
+    return 0;
+}
+
+//returns 1 if matched 
+int preg_test(const char *regex, const char *string){
+    regex_t preg;
+    //int convert_result;
+    int test_result = 0;
+
+    //Convert regex string to type regex_t
+    //TODO: Handle the convert result
+    regcomp(&preg, regex, REG_EXTENDED);
+    if (regex != NULL && regexec(&preg, string, 0, NULL, 0) == 0){
+        test_result = 1;
+    }
+    regfree(&preg);
+    return test_result;
+}
+
+/**
+ * @param message
+ * 
+ * @return if return 0, pass and display this message
+ */
+int filter_filter_check_message(
+        const char *channel_name,
+        const char *nick_name,
+        const char *message
+){
+    GList *lst;
+    FilterItem *item;
+    int test_result = 0;
+
+    if (disable_filter == 1){
+        return 0;
+    }
+    lst = filter_list;
+    while(lst){
+        item = lst->data;
+
+        if (!channel_name){
+            test_result =
+                preg_test(item->regex, message) ||
+                preg_test(item->regex, nick_name);
+
+            if (test_result != 0){
+                return 1;
+            }
+        }
+        /* If specified a channel_name or channel_name is * */
+        else if (strncmp(channel_name, item->channel_name, CHAN_LEN) == 0
+            || strncmp("*", item->channel_name, 2) == 0){
+            test_result =
+                preg_test(item->regex, message) ||
+                preg_test(item->regex, nick_name);
+
+            if (test_result != 0){
+                return 1;
+            }
+		}
+        lst = lst->next;
+    }
+    return 0;
 }

--- a/src/inc/filter.h
+++ b/src/inc/filter.h
@@ -1,11 +1,26 @@
 #ifndef __FILTER_H
 #define __FILTER_H
 
+#define FILTER_MAX_LEN 50
+#define FILTER_NAME_MAX_LEN 50
+
+typedef struct {
+    char name[FILTER_NAME_MAX_LEN];      //Filter's name
+    char channel_name[32];               //Channel affected by this filter
+    char regex[FILTER_MAX_LEN];          //Regex
+} FilterItem;
+
 int filter_ignore_list_add(const char *nick);
 int filter_ignore_list_rm(const char *nick);
 int filter_relaybot_list_add(const char *nick, const char *ldelim, const char *rdelim);
 int filter_relaybot_list_rm(const char *nick);
 int filter_is_ignore(const char *nick);
 void filter_relaybot_trans(const char *orgin_nick, char *nick, char *msg);
+
+int filter_filter_add_filter(const char *name, const char *regex, const char *channel_name);
+int filter_filter_remove_filter(const char *filter_name);
+int filter_filter_show();
+int filter_filter_check_message(const char *channel_name, const char *nick_name, const char *message);
+
 
 #endif /* __FILTER_H */

--- a/src/srv/srv_event.c
+++ b/src/srv/srv_event.c
@@ -349,14 +349,14 @@ void srv_event_channel(irc_session_t *irc_session, const char *event,
 
     /* A message sent by relay bot */
     if (strlen(nick) > 0){
-        if (!filter_is_ignore(nick)){
+        if (!filter_is_ignore(nick) && !filter_filter_check_message(chan, nick, pure_msg)){
             if (!plugin_avatar_has_queried(nick)) srv_session_who(sess, nick);
 
             int flag = strstr(pure_msg, sess->nickname) ? SRAIN_MSG_MENTIONED : 0;
             srv_hdr_ui_recv_msg(sess->host, chan, nick, origin, pure_msg, flag);
         }
     } else {
-        if (!filter_is_ignore(origin)){
+        if (!filter_is_ignore(origin) && !filter_filter_check_message(chan, origin, pure_msg)){
             if (!plugin_avatar_has_queried(origin))
                 srv_session_who(sess, origin);
 
@@ -387,7 +387,7 @@ void srv_event_privmsg(irc_session_t *irc_session, const char *event,
 
     chat_log_fmt(sess->host, origin, "<%s> %s", origin, pure_msg);
 
-    if (!filter_is_ignore(origin))
+    if (!filter_is_ignore(origin) && !filter_filter_check_message(NULL, origin, pure_msg))
         srv_hdr_ui_recv_msg(sess->host, origin, origin, "", pure_msg, 0);
 
     free(pure_msg);

--- a/src/srv/srv_session_cmd.c
+++ b/src/srv/srv_session_cmd.c
@@ -31,6 +31,9 @@ static int on_command_connect(Command *cmd, void *user_data);
 static int on_command_relay(Command *cmd, void *user_data);
 static int on_command_unrelay(Command *cmd, void *user_data);
 static int on_command_ignore(Command *cmd, void *user_data);
+static int on_command_filter(Command *cmd, void *user_data);
+static int on_command_filter_show(Command *cmd, void *user_data);
+static int on_command_unfilter(Command *cmd, void *user_data);
 static int on_command_unignore(Command *cmd, void *user_data);
 static int on_command_query(Command *cmd, void *user_data);
 static int on_command_unquery(Command *cmd, void *user_data);
@@ -86,10 +89,28 @@ static CommandBind cmd_binds[] = {
         on_command_unignore
     },
     {
+        "/filter", 3, // <filter name> <channel> <regex>
+        {NULL},
+        {NULL},
+        on_command_filter
+    },
+    {
+        "/unfilter", 1, // <filter name>
+        {NULL},
+        {NULL},
+        on_command_unfilter
+    },
+    {
         "/query", 1, // <nick>
         {NULL},
         {NULL},
         on_command_query
+    },
+    {
+        "/filterlist", 0,
+        {NULL},
+        {NULL},
+        on_command_filter_show
     },
     {
         "/unquery", 1, // <nick>
@@ -245,6 +266,27 @@ static int on_command_unignore(Command *cmd, void *user_data){
 
     if (!nick) return -1;
     return filter_ignore_list_rm(nick);
+}
+
+static int on_command_filter(Command *cmd, void *user_data){
+    const char *name = command_get_arg(cmd, 0);
+    const char *channel_name = command_get_arg(cmd, 1);
+    const char *regex = command_get_arg(cmd, 2);
+
+    if(!name || !channel_name || !regex)
+        return -1;
+    return filter_filter_add_filter(name, regex, channel_name);
+}
+
+static int on_command_unfilter(Command *cmd, void *user_data){
+    const char *name = command_get_arg(cmd, 0);
+    if (!name) return -1;
+
+    return filter_filter_remove_filter(name);
+}
+
+static int on_command_filter_show(Command *cmd, void *user_data){
+    return filter_filter_show();
 }
 
 static int on_command_query(Command *cmd, void *user_data){


### PR DESCRIPTION
Add comman: /filter and /unfilter
Usage:
/filter filter_name #channel_name regex
/unfilter filter_name

example:
/filter test_a #lasttest .\*test.\*
/unfilter test_a

It's also allowed to create a filter can affect all channels, just change #channel_name to \*

TODO: Add enable/disable filter command and make it affect to chat log.