### PR TITLE
SrnRet and /server command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Srain's git repositories.
 - Changed:
 
   - The third time of refactor ;-)
-  - New command parser, for the syntax, refer to ``./doc/commands.rst``
+  - New command parser, for the syntax, refer to ``docs/commands.rst``
   - Changed the format of Chat log
   - The ``/relay`` command doesn't support custom delimiter, this function will
     be implemented as python plugin in the future
@@ -25,7 +25,8 @@ Srain's git repositories.
   - Install script for Gentoo, thanks to @rtlanceroad !
   - Support to ignore message using  regular expression, thanks to @zwindl !
     Use command ``/rignore <name> <pattern>`` to have a try.
-  - Config file support [WIP]
+  - Config file support
+  - Configurable log module, more convenient for developing and reporting issue
 
 - Removed:
 

--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -18,12 +18,14 @@ A ``option`` starts with a ``-`` and may has a value.
 
 Command::
 
-    /server [add|rm|set|connect|disconnect] [-port <port>] [-tls on|off|notverify]
-    [-realname <realname>] [-passwd <passwd>] [-host <host>] [-nick <nick>] <name>
+    /server [add|rm|set|connect|disconnect]
+        [-host <host>] [-port <port>] [-passwd <password>] [-tls] [-tls_]
+        [-nick <nickname>] [-user <username>] [-real <realname>] <name>
 
 Command::
 
-    /connect [-port <port>] [-ssl on|off|notverify] [-realname <realname>] [-passwd <passwd>] <host> <nick>
+    /connect [-port <port>]  [-pwd <password>] [-tls] [-tls-valid-all]
+        [-user <username>] [-real <realname>] <host> <nick>
 
 Add a server into your server list. It will become the default server
 automaticly.
@@ -31,18 +33,15 @@ automaticly.
 * ``host``: IRC server host
 * ``nick``: The nickname you want to use
 * ``-port``: IRC server port, if no specified, use ``6667``
-* ``-ssl``:
-
-  - ``on``: Use secure server connections with SSL
-  - ``off``: On the contrary
-  - ``notverify``: Disables the certificate verification
-
-* ``-passwd``: The password of the server
-* ``-realname``: Set your realname
+* ``-pwd``: The password of the server
+* ``-tls``: Use secure connections with TLS
+* ``-tls-valid-all``: Don't verify TLS certificate
+* ``-user``: Set your username
+* ``-real``: Set your realname
 
 Example::
 
-    /connect -realname 'I am srainbot' -ssl notverify -port 6697 chat.freenode.org srainbot
+    /connect -real 'I am srainbot' -tls -port 6697 chat.freenode.org srainbot
     /connect 127.0.0.1 srainbot
 
 **The following commands should excuted after a ``/connect`` command**

--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -2,6 +2,25 @@
 Commands
 ========
 
+Syntax
+======
+
+Syntax::
+
+    <command> [subcommand] [option] [argument]
+
+A ``command`` is a string starts with a slash ``/`` and doesn't contain any
+whitespace, e.g. ``/join``
+
+A ``subcommand`` is a specified the detailed operation of this command.
+
+A ``option`` starts with a ``-`` and may has a value.
+
+Command::
+
+    /server [add|rm|set|connect|disconnect] [-port <port>] [-tls on|off|notverify]
+    [-realname <realname>] [-passwd <passwd>] [-host <host>] [-nick <nick>] <name>
+
 Command::
 
     /connect [-port <port>] [-ssl on|off|notverify] [-realname <realname>] [-passwd <passwd>] <host> <nick>

--- a/doc/commands.rst
+++ b/doc/commands.rst
@@ -24,7 +24,7 @@ Command::
 
 Command::
 
-    /connect [-port <port>]  [-pwd <password>] [-tls] [-tls-valid-all]
+    /connect [-port <port>]  [-pwd <password>] [-tls] [-tls-not-verify]
         [-user <username>] [-real <realname>] <host> <nick>
 
 Add a server into your server list. It will become the default server
@@ -35,7 +35,7 @@ automaticly.
 * ``-port``: IRC server port, if no specified, use ``6667``
 * ``-pwd``: The password of the server
 * ``-tls``: Use secure connections with TLS
-* ``-tls-valid-all``: Don't verify TLS certificate
+* ``-tls-not-verify``: Don't verify TLS certificate
 * ``-user``: Set your username
 * ``-real``: Set your realname
 

--- a/src/command.c
+++ b/src/command.c
@@ -61,14 +61,14 @@ SrnRet command_proc(CommandContext *ctx, const char *rawcmd, void *user_data){
                 ret = cmd->bind->cb(cmd, user_data);
             } else if (ret == SRN_ERR) {
                 // TODO: decorate
-                ret = ERR(_("Sorry, command parse failed, please report a bug to <" PACKAGE_WEBSITE "/issues> ."));
+                ret = RET_ERR(_("Sorry, command parse failed, please report a bug to <" PACKAGE_WEBSITE "/issues> ."));
             }
             command_free(cmd);
             return ret;
         }
     }
 
-    return ERR(_("Unknown command: %s"), rawcmd);
+    return RET_ERR(_("Unknown command: %s"), rawcmd);
 }
 
 /**
@@ -219,7 +219,7 @@ static SrnRet get_quote_arg(char *ptr, char **arg, char **next){
     }
 
     if (quote){
-        return ERR(_("Unclosed single quotation"));
+        return RET_ERR(_("Unclosed single quotation"));
     }
 
     next_in = ptr;
@@ -367,25 +367,25 @@ missing_arg:
     if (cmd->bind->flag & COMMAND_FLAG_OMIT_ARG){
         return SRN_OK;
     }
-    return ERR(_("Missing argument, expect %d, actually %d"), cmd->bind->argc, narg);
+    return RET_ERR(_("Missing argument, expect %d, actually %d"), cmd->bind->argc, narg);
 
 unknown_opt:
-    return ERR(_("Unknown option %s"), cmd->opt_key[nopt]);
+    return RET_ERR(_("Unknown option %s"), cmd->opt_key[nopt]);
 
 too_many_opt:
-    return ERR(_("Too many options, options count limit to %d"), COMMAND_MAX_OPTS);
+    return RET_ERR(_("Too many options, options count limit to %d"), COMMAND_MAX_OPTS);
 
 missing_opt_val:
-    return ERR(_("Missing vaule for option %s"), cmd->opt_key[nopt]);
+    return RET_ERR(_("Missing vaule for option %s"), cmd->opt_key[nopt]);
 
 unknown_subcmd:
-    return ERR(_("Unknown sub command: %s"), ptr);
+    return RET_ERR(_("Unknown sub command: %s"), ptr);
 
 #if 0
 too_many_arg:
     /* Currently, we regard all remaining text as the last argument, so this
      * label is never used. */
-    return ERR(_("Too many arguments, expect %d"), cmd->bind->argc);
+    return RET_ERR(_("Too many arguments, expect %d"), cmd->bind->argc);
 #endif
 }
 

--- a/src/command.c
+++ b/src/command.c
@@ -105,7 +105,7 @@ const char *command_get_arg(Command *cmd, unsigned index){
  *      have a value, it will be return to the ``opt_key``
  *
  */
-bool command_get_opt(Command *cmd, const char *opt_key, char **opt_val){
+bool command_get_opt(Command *cmd, const char *opt_key, const char **opt_val){
     unsigned i = 0;
 
     while (cmd->opt_key[i] != NULL){

--- a/src/command_test.c
+++ b/src/command_test.c
@@ -11,7 +11,6 @@
 
 static int on_command_connect_test(Command *cmd, void *user_data);
 static int on_command_topic_test(Command *cmd, void *user_data);
-static void on_anything_error();
 
 static CommandBind cmd_binds_test[] = {
     {
@@ -37,13 +36,6 @@ static CommandBind cmd_binds_test[] = {
 
 static CommandContext context_test = {
     .binds = cmd_binds_test,
-    .on_unknown_cmd = on_anything_error,
-    .on_unknown_opt = on_anything_error,
-    .on_missing_opt_val = on_anything_error,
-    .on_missing_arg = on_anything_error,
-    .on_too_many_opt = on_anything_error,
-    .on_too_many_arg = on_anything_error,
-    .on_callback_fail = on_anything_error,
 };
 
 void command_test(){
@@ -124,8 +116,4 @@ static int on_command_topic_test(Command *cmd, void *user_data){
             }
     }
     return 0;
-}
-
-static void on_anything_error(){
-    LOG_FR("Some error occured");
 }

--- a/src/inc/command.h
+++ b/src/inc/command.h
@@ -58,7 +58,7 @@ typedef struct {
 
 int command_proc(CommandContext *ctx, const char *rawcmd, void *user_data);
 const char *command_get_arg(Command *cmd, unsigned index);
-bool command_get_opt(Command *cmd, const char *opt_key, char **opt_val);
+bool command_get_opt(Command *cmd, const char *opt_key, const char **opt_val);
 
 void command_test();
 void get_quote_arg_test();

--- a/src/inc/command.h
+++ b/src/inc/command.h
@@ -2,6 +2,7 @@
 #define __COMMAND_H
 
 #include "srain.h"
+#include "ret.h"
 
 #define COMMAND_MAX_OPTS        20
 #define COMMAND_MAX_ARGS        20
@@ -56,7 +57,7 @@ typedef struct {
     void (*on_callback_fail) (Command *cmd, void *user_data);
 } CommandContext;
 
-int command_proc(CommandContext *ctx, const char *rawcmd, void *user_data);
+SrnRet command_proc(CommandContext *ctx, const char *rawcmd, void *user_data);
 const char *command_get_arg(Command *cmd, unsigned index);
 bool command_get_opt(Command *cmd, const char *opt_key, const char **opt_val);
 

--- a/src/inc/command.h
+++ b/src/inc/command.h
@@ -48,13 +48,6 @@ struct _Command {
 
 typedef struct {
     CommandBind *binds;
-    void (*on_unknown_cmd) (const char *cmd, void *user_data);
-    void (*on_unknown_opt) (Command *cmd, const char *opt, void *user_data);
-    void (*on_missing_opt_val) (Command *cmd, const char *opt, void *user_data);
-    void (*on_missing_arg) (Command *cmd, int narg, void *user_data);
-    void (*on_too_many_opt) (Command *cmd, void *user_data);
-    void (*on_too_many_arg) (Command *cmd, void *user_data);
-    void (*on_callback_fail) (Command *cmd, void *user_data);
 } CommandContext;
 
 SrnRet command_proc(CommandContext *ctx, const char *rawcmd, void *user_data);

--- a/src/inc/command.h
+++ b/src/inc/command.h
@@ -24,7 +24,7 @@
 typedef int CommandFlag;
 typedef struct _Command Command;
 
-typedef int (CommandCallback) (Command *cmd, void *user_data);
+typedef SrnRet (CommandCallback) (Command *cmd, void *user_data);
 
 typedef struct {
     char *name;

--- a/src/inc/log.h
+++ b/src/inc/log.h
@@ -64,9 +64,6 @@ struct _LogPrefs {
 #define ERR_F(...) \
     log_print(LOG_ERROR, TRUE, FALSE, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 
-#define ERR(...) \
-    log_print(LOG_ERROR, FALSE, FALSE, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
-
 void log_init();
 void log_read_prefs();
 void log_finalize();

--- a/src/inc/rc.h
+++ b/src/inc/rc.h
@@ -1,7 +1,9 @@
 #ifndef __RC_H
 #define __RC_H
 
-int rc_read();
+#include "ret.h"
+
+SrnRet rc_read();
 
 #endif /* __RC_H */
 

--- a/src/inc/ret.h
+++ b/src/inc/ret.h
@@ -8,8 +8,10 @@
 /* Just alias */
 #define RET_OK(...) ret_ok(__VA_ARGS__)
 #define RET_ERR(...) ret_err(__VA_ARGS__)
-#define RET_IS_OK(id) ((id) == SRN_OK || ret_get_no((id)) == SRN_OK)
-#define RET_IS_ERR(id) ((id) == SRN_ERR || ret_get_no((id)) == SRN_ERR)
+#define RET_IS_OK(id) ({ typeof (id) _id = (id); \
+        (_id == SRN_OK || ret_get_no(_id) == SRN_OK);})
+#define RET_IS_ERR(id) ({ typeof (id) _id = (id); \
+        (_id == SRN_ERR || ret_get_no(_id) == SRN_ERR);})
 #define RET_MSG(id) ret_get_message((id))
 
 typedef int SrnRet;

--- a/src/inc/ret.h
+++ b/src/inc/ret.h
@@ -1,19 +1,24 @@
 #ifndef __RET_H
 #define __RET_H
 
-/* Just alias */
-#define ERR(...) ret_err(__VA_ARGS__)
-#define ERRMSG(id) ret_errmsg((id))
-
-/* Reserved error id */
+/* Reserved return id */
 #define SRN_OK      0   // No error occurred
 #define SRN_ERR    -1   // Unknown/Unspecified error
+
+/* Just alias */
+#define RET_OK(...) ret_ok(__VA_ARGS__)
+#define RET_ERR(...) ret_err(__VA_ARGS__)
+#define RET_IS_OK(id) ((id) == SRN_OK || ret_get_no((id)) == SRN_OK)
+#define RET_IS_ERR(id) ((id) == SRN_ERR || ret_get_no((id)) == SRN_ERR)
+#define RET_MSG(id) ret_get_message((id))
 
 typedef int SrnRet;
 
 void ret_init();
 void ret_finalize();
 SrnRet ret_err(const char *fmt, ...);
-const char *ret_errmsg(int id);
+SrnRet ret_ok(const char *fmt, ...);
+const char *ret_get_message(SrnRet id);
+int ret_get_no(SrnRet id);
 
 #endif /* __RET_H */

--- a/src/inc/ret.h
+++ b/src/inc/ret.h
@@ -1,0 +1,19 @@
+#ifndef __RET_H
+#define __RET_H
+
+/* Just alias */
+#define ERR(...) ret_err(__VA_ARGS__)
+#define ERRMSG(id) ret_errmsg((id))
+
+/* Reserved error id */
+#define SRN_OK      0   // No error occurred
+#define SRN_ERR    -1   // Unknown/Unspecified error
+
+typedef int SrnRet;
+
+void ret_init();
+void ret_finalize();
+SrnRet ret_err(const char *fmt, ...);
+const char *ret_errmsg(int id);
+
+#endif /* __RET_H */

--- a/src/inc/server.h
+++ b/src/inc/server.h
@@ -6,6 +6,7 @@
 
 #include "sirc/sirc.h"
 #include "sui/sui.h"
+#include "ret.h"
 
 /* In millseconds */
 #define SERVER_PING_INTERVAL    (60 * 1000)
@@ -195,7 +196,7 @@ void message_free(Message *msg);
 void server_prefs_list_init();
 ServerPrefs* server_prefs_new(const char *name);
 ServerPrefs* server_prefs_get_prefs(const char *name);
-bool server_prefs_is_valid(ServerPrefs *prefs);
+SrnRet server_prefs_is_valid(ServerPrefs *prefs);
 void server_prefs_free(ServerPrefs *prefs);
 
 /* Server list */

--- a/src/inc/server.h
+++ b/src/inc/server.h
@@ -29,7 +29,6 @@ typedef struct _Message Message;
 typedef struct _User User;
 typedef struct _Chat Chat;
 typedef enum   _ServerStatus ServerStatus;
-typedef struct _ServerInfo ServerInfo;
 typedef struct _Server Server;
 typedef struct _ServerPrefs ServerPrefs;
 
@@ -113,7 +112,6 @@ struct _Server {
     ServerStatus stat;
     bool registered;    // Whether the user has registered(Own a nickname)?
     bool user_quit;     // Whether the user has received a QUIT message originated by himself?
-    ServerInfo *info;
     ServerPrefs *prefs;
     User *user;         // Used to store your nick, username, realname
     Chat *chat;         // Hold all messages that do not belong to any other Chat
@@ -149,6 +147,9 @@ struct _ServerPrefs {
     char *quit_message;
 
     SircPrefs *irc;
+
+    // ...
+    Server *srv;
 };
 
 void server_init();
@@ -192,7 +193,8 @@ Message* message_new(Chat *chat, User *user, const char *content, MessageType ty
 void message_free(Message *msg);
 
 void server_prefs_list_init();
-ServerPrefs* server_prefs_new();
+ServerPrefs* server_prefs_new(const char *name);
+ServerPrefs* server_prefs_get_prefs(const char *name);
 bool server_prefs_is_valid(ServerPrefs *prefs);
 void server_prefs_free(ServerPrefs *prefs);
 

--- a/src/inc/server.h
+++ b/src/inc/server.h
@@ -103,7 +103,6 @@ struct _Chat {
 };
 
 enum _ServerStatus {
-    SERVER_UNCONNECTED,
     SERVER_CONNECTING,
     SERVER_CONNECTED,
     SERVER_DISCONNECTED,

--- a/src/inc/server_cmd.h
+++ b/src/inc/server_cmd.h
@@ -2,8 +2,9 @@
 #define __SERVER_CMD_H
 
 #include "server.h"
+#include "ret.h"
 
 void server_cmd_init();
-int server_cmd(Chat *chat, const char *cmd);
+SrnRet server_cmd(Chat *chat, const char *cmd);
 
 #endif /* __SERVER_CMD_H */

--- a/src/inc/sirc/sirc_prefs.h
+++ b/src/inc/sirc/sirc_prefs.h
@@ -6,6 +6,7 @@
 #endif
 
 #include "srain.h"
+#include "ret.h"
 
 typedef struct _SircPrefs SircPrefs;
 
@@ -18,7 +19,7 @@ struct _SircPrefs {
 };
 
 SircPrefs *sirc_prefs_new();
-bool sirc_prefs_is_valid(SircPrefs *prefs);
+SrnRet sirc_prefs_is_valid(SircPrefs *prefs);
 void sirc_prefs_free(SircPrefs *prefs);
 
 #endif /* __SIRC_PREFS_H */

--- a/src/inc/sui/sui_prefs.h
+++ b/src/inc/sui/sui_prefs.h
@@ -6,6 +6,7 @@
 #endif
 
 #include "srain.h"
+#include "ret.h"
 
 typedef struct _SuiAppPrefs SuiAppPrefs;
 typedef struct _SuiPrefs SuiPrefs;
@@ -24,11 +25,11 @@ struct _SuiPrefs {
 };
 
 SuiAppPrefs *sui_app_prefs_new();
-bool sui_app_prefs_is_valid(SuiAppPrefs *prefs);
+SrnRet sui_app_prefs_is_valid(SuiAppPrefs *prefs);
 void sui_app_prefs_free(SuiAppPrefs *prefs);
 
 SuiPrefs *sui_prefs_new();
-bool sui_prefs_is_valid(SuiPrefs *prefs);
+SrnRet sui_prefs_is_valid(SuiPrefs *prefs);
 void sui_prefs_free(SuiPrefs *prefs);
 
 #endif /* __SUI_PREFS_H */

--- a/src/inc/utils.h
+++ b/src/inc/utils.h
@@ -6,5 +6,6 @@
 unsigned long get_time_since_first_call_ms(void);
 time_t get_current_time_s(void);
 void time_to_str(time_t time, char *timestr, size_t size, const char *fmt);
+void str_assign(char **left, const char *right);
 
 #endif /* __UTILS_H */

--- a/src/rc.c
+++ b/src/rc.c
@@ -20,6 +20,7 @@
 #include "meta.h"
 #include "i18n.h"
 #include "log.h"
+#include "rc.h"
 #include "file_helper.h"
 
 SrnRet rc_read(){

--- a/src/rc.c
+++ b/src/rc.c
@@ -50,7 +50,7 @@ SrnRet rc_read(){
     while ((read = getline(&line, &len, fp)) != -1) {
         if (line && line[0] != '#'){
             strtok(line, "\n");
-            if ((ret = server_cmd(NULL, line)) != SRN_OK){
+            if (!RET_IS_OK(ret = server_cmd(NULL, line))){
                 ret = RET_ERR("Command failed at line %d: %s", nline, RET_MSG(ret));
                 break;
             }

--- a/src/rc.c
+++ b/src/rc.c
@@ -55,6 +55,7 @@ SrnRet rc_read(){
                 break;
             }
         }
+        nline++;
     }
 
 fin:

--- a/src/rc.c
+++ b/src/rc.c
@@ -34,13 +34,13 @@ SrnRet rc_read(){
 
     rc_file = get_config_file("srainrc");
     if (!rc_file) {
-        ret = ERR(_("Rc file not found: %s"), rc_file);
+        ret = RET_ERR(_("Rc file not found: %s"), rc_file);
         goto fin;
     }
 
     fp = fopen(rc_file, "r");
     if (!fp){
-        ret = ERR(_("Can not open rc file: %s"), rc_file);
+        ret = RET_ERR(_("Can not open rc file: %s"), rc_file);
         goto fin;
     }
 
@@ -51,7 +51,7 @@ SrnRet rc_read(){
         if (line && line[0] != '#'){
             strtok(line, "\n");
             if ((ret = server_cmd(NULL, line)) != SRN_OK){
-                ret = ERR("Command failed at line %d: %s", nline, ERRMSG(ret));
+                ret = RET_ERR("Command failed at line %d: %s", nline, RET_MSG(ret));
                 break;
             }
         }

--- a/src/rc.c
+++ b/src/rc.c
@@ -9,7 +9,6 @@
  * call `server_cmd()` for every line
  */
 
-
 #include <stdio.h>
 #include <string.h>
 #include <gtk/gtk.h>
@@ -23,40 +22,49 @@
 #include "log.h"
 #include "file_helper.h"
 
-int rc_read(){
-    FILE *fp;
+SrnRet rc_read(){
+    int nline;
+    FILE *fp = NULL;
     char *line;
     size_t len;
     ssize_t read;
-    char *rc_file;
+    char *rc_file = NULL;
+    SrnRet ret = SRN_OK;
 
     rc_file = get_config_file("srainrc");
-    if (!rc_file) return SRN_ERR;
+    if (!rc_file) {
+        ret = ERR(_("Rc file not found: %s"), rc_file);
+        goto fin;
+    }
 
     fp = fopen(rc_file, "r");
-
     if (!fp){
-        ERR_FR("Failed to open %s", rc_file);
-        g_free(rc_file);
-        return SRN_ERR;
+        ret = ERR(_("Can not open rc file: %s"), rc_file);
+        goto fin;
     }
-    g_free(rc_file);
 
     len = 0;
+    nline = 1;
     line = NULL;
     while ((read = getline(&line, &len, fp)) != -1) {
         if (line && line[0] != '#'){
             strtok(line, "\n");
-            if (server_cmd(NULL, line) != SRN_OK){
-                ERR_FR("Command failed: %s", line);
+            if ((ret = server_cmd(NULL, line)) != SRN_OK){
+                ret = ERR("Command failed at line %d: %s", nline, ERRMSG(ret));
                 break;
             }
         }
     }
 
-    if (line) free(line);
-
-    fclose(fp);
-
-    return SRN_OK;
+fin:
+    if (rc_file) {
+        g_free(rc_file);
+    }
+    if (fp){
+        fclose(fp);
+    }
+    if (line) {
+        free(line);
+    }
+    return ret;
 }

--- a/src/ret.c
+++ b/src/ret.c
@@ -114,6 +114,6 @@ static SrnErr* srn_err_new(int id, const char *msg){
 }
 
 static void srn_err_free(SrnErr *err){
-    g_free(&err->msg);
+    g_free(err->msg);
     g_free(err);
 }

--- a/src/ret.c
+++ b/src/ret.c
@@ -10,6 +10,7 @@
 
 #include "i18n.h"
 #include "ret.h"
+#include "log.h"
 
 #define SRN_RET_MESSAGE_COUNT 512
 
@@ -157,7 +158,10 @@ static SrnRetMessage* srn_ret_message_new(SrnRet id, int no, const char *msg){
 
     rmsg = g_malloc0(sizeof(SrnRetMessage));
     rmsg->id = id;
+    rmsg->no = no;
     rmsg->msg = g_strdup(msg);
+
+    DBG_FR("SrnRet: id: %d, no: %d, msg: %s", id, no, msg);
 
     return rmsg;
 }

--- a/src/ret.c
+++ b/src/ret.c
@@ -1,0 +1,119 @@
+/**
+ * @file ret.c
+ * @brief Srain return value, support for returning error message
+ * @author Shengyu Zhang <silverrainz@outlook.com>
+ * @version 1.0
+ * @date 2017-07-13
+ */
+
+#include <glib.h>
+
+#include "i18n.h"
+#include "ret.h"
+
+#define SRN_RET_ERR_COUNT 512
+
+typedef struct _SrnErr SrnErr;
+
+struct _SrnErr {
+    int id;
+    char *msg;
+};
+
+static int errid = 0;
+static GSList *err_list = NULL;
+static GMutex mutex;
+
+static SrnErr* srn_err_new(int id, const char *msg);
+static void srn_err_free(SrnErr *err);
+
+void ret_init(){
+    g_mutex_init(&mutex);
+}
+
+void ret_finalize(){
+    g_slist_free_full(err_list, (GDestroyNotify)srn_err_free);
+}
+
+SrnRet ret_err(const char *fmt, ...){
+    int id;
+    va_list args;
+    GString *msg;
+    SrnErr *err;
+
+    g_mutex_lock(&mutex);
+
+    if (g_slist_length(err_list) > SRN_RET_ERR_COUNT){
+        // If err_list full
+        GSList *last;
+        last = g_slist_last(err_list);
+        srn_err_free((SrnErr *)last->data);
+        err_list = g_slist_delete_link(err_list, last);
+    }
+
+    msg = g_string_new(NULL);
+    va_start(args, fmt);
+    g_string_append_vprintf(msg, fmt, args);
+    va_end(args);
+
+    err = srn_err_new(++errid, msg->str);
+    g_string_free(msg, TRUE);
+
+    err_list = g_slist_prepend(err_list, err);
+
+    g_mutex_unlock(&mutex);
+
+    return err->id;
+}
+
+const char *ret_errmsg(int id){
+    const char *msg;
+    GSList *lst;
+    SrnErr *err;
+
+    g_mutex_lock(&mutex);
+
+    if (id == SRN_OK) {
+        msg =  _("No error occurred");
+        goto fin;
+    }
+    if (id == SRN_ERR) {
+        msg = _("Some error occurred");
+        goto fin;
+    }
+
+    msg = NULL;
+    lst = err_list;
+    while (lst){
+        err = lst->data;
+
+        if (err->id == id) {
+            msg = err->msg;
+            break;
+        }
+        lst = g_slist_next(lst);
+    }
+
+fin:
+    g_mutex_unlock(&mutex);
+    if (!msg){
+        msg = _("Invalid error id, maybe this error is removed because out of date");
+    }
+
+    return msg;
+}
+
+static SrnErr* srn_err_new(int id, const char *msg){
+    SrnErr *err;
+
+    err = g_malloc0(sizeof(SrnErr));
+    err->id = id;
+    err->msg = g_strdup(msg);
+
+    return err;
+}
+
+static void srn_err_free(SrnErr *err){
+    g_free(&err->msg);
+    g_free(err);
+}

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -98,7 +98,7 @@ void server_finalize(){
 Server* server_new_from_prefs(ServerPrefs *prefs){
     Server *srv;
 
-    // g_return_val_if_fail(server_prefs_is_valid(prefs), NULL);
+    g_return_val_if_fail(server_prefs_is_valid(prefs) == SRN_OK, NULL);
     g_return_val_if_fail(!server_list_get_server(prefs->name), NULL);
 
     srv = g_malloc0(sizeof(Server));

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -97,7 +97,7 @@ void server_finalize(){
 Server* server_new_from_prefs(ServerPrefs *prefs){
     Server *srv;
 
-    g_return_val_if_fail(server_prefs_is_valid(prefs), NULL);
+    // g_return_val_if_fail(server_prefs_is_valid(prefs), NULL);
     g_return_val_if_fail(!server_list_get_server(prefs->name), NULL);
 
     srv = g_malloc0(sizeof(Server));

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -23,6 +23,7 @@
 #include "log.h"
 #include "utils.h"
 #include "prefs.h"
+#include "i18n.h"
 
 SuiAppEvents ui_app_events;
 SuiEvents ui_events;
@@ -76,7 +77,7 @@ void server_init(){
 
     errmsg = prefs_read();
     if (errmsg){
-        ERR_FR("Read prefs failed: %s", errmsg);
+        sui_message_box(_("Prefs read error"), errmsg);
         g_free(errmsg);
     }
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -105,7 +105,7 @@ Server* server_new_from_prefs(ServerPrefs *prefs){
 
     srv->registered = FALSE;
     srv->user_quit = FALSE;
-    srv->stat = SERVER_UNCONNECTED;
+    srv->stat = SERVER_DISCONNECTED;
     srv->prefs = prefs;
 
     srv->chat = chat_new(srv, META_SERVER);

--- a/src/server/server_cmd.c
+++ b/src/server/server_cmd.c
@@ -299,7 +299,7 @@ static SrnRet on_command_server(Command *cmd, void *user_data){
 
     subcmd = cmd->subcmd;
     if (!subcmd) {
-        return ERR(_("No subcommand specified"));
+        return RET_ERR(_("No subcommand specified"));
     }
 
     if (g_ascii_strcasecmp(subcmd, "add") == 0){
@@ -309,7 +309,7 @@ static SrnRet on_command_server(Command *cmd, void *user_data){
     }
 
     if (!prefs){
-        return ERR("Failed to get/create ServerPrefs '%s'", name);
+        return RET_ERR("Failed to get/create ServerPrefs '%s'", name);
     }
 
     if (g_ascii_strcasecmp(subcmd, "add") == 0){
@@ -370,7 +370,7 @@ static SrnRet on_command_server(Command *cmd, void *user_data){
 
         if (!server_is_registered(srv)){
             server_free(srv);
-            return ERR(_("Failed to register on server '%s'"), prefs->name);
+            return RET_ERR(_("Failed to register on server '%s'"), prefs->name);
         }
 
         def_srv = srv;
@@ -382,11 +382,11 @@ static SrnRet on_command_server(Command *cmd, void *user_data){
         srv = server_list_get_server(name);
         if (!srv) {
             // FIXME: better errmsg?
-            return ERR(_("Can not disconnect from a server which is not connected"));
+            return RET_ERR(_("Can not disconnect from a server which is not connected"));
         }
 
         if (srv->stat != SERVER_CONNECTED){
-            return ERR(_("Can not disconnect from a server which is not connected"));
+            return RET_ERR(_("Can not disconnect from a server which is not connected"));
         }
 
         server_disconnect(srv);
@@ -398,7 +398,7 @@ static SrnRet on_command_server(Command *cmd, void *user_data){
         srv = server_list_get_server(name);
         if (srv) {
             if (srv->stat == SERVER_CONNECTED) {
-                return ERR(_("Can not remove a server which is still connected"));
+                return RET_ERR(_("Can not remove a server which is still connected"));
             }
             server_free(srv);
         }
@@ -407,7 +407,7 @@ static SrnRet on_command_server(Command *cmd, void *user_data){
         if (prefs){
             server_prefs_free(prefs);
         } else {
-            return ERR(_("No such server: %s"), name);
+            return RET_ERR(_("No such server: %s"), name);
         }
     }
 
@@ -435,7 +435,7 @@ static SrnRet on_command_connect(Command *cmd, void *user_data){
 
     prefs = server_prefs_new(host);
     if (!prefs){
-        return ERR("Failed to create ServerPrefs '%s'", host);
+        return RET_ERR("Failed to create ServerPrefs '%s'", host);
     }
 
     errmsg = prefs_read_server_prefs(prefs);
@@ -477,7 +477,7 @@ static SrnRet on_command_connect(Command *cmd, void *user_data){
 
     srv = server_new_from_prefs(prefs);
     if (!srv) {
-        return ERR(_("Failed to create server %s"), prefs->name);
+        return RET_ERR(_("Failed to create server %s"), prefs->name);
     }
 
     def_srv = srv;
@@ -487,7 +487,7 @@ static SrnRet on_command_connect(Command *cmd, void *user_data){
 
     if (!server_is_registered(srv)){
         def_srv = NULL;
-        return ERR(_("Failed to register on server %s"), prefs->name);
+        return RET_ERR(_("Failed to register on server %s"), prefs->name);
     }
 
     return SRN_OK;

--- a/src/server/server_cmd.c
+++ b/src/server/server_cmd.c
@@ -73,7 +73,7 @@ CommandBind cmd_binds[] = {
         .opt_key =
         {"-host", "-port", "-tls", "-tls-valid-all", "-pwd", "-nick", "-user", "-real", "-encode",  NULL},
         .opt_default_val =
-        {NULL, "6667", NULL, NULL, "Zaidan", "Srain", "Can you can a can?", "UTF-8", NULL},
+        {NULL, "6667", NULL, NULL, NULL, "Zaidan", "Srain", "Can you can a can?", "UTF-8", NULL},
         .flag = 0,
         .cb = on_command_server,
     },
@@ -81,9 +81,9 @@ CommandBind cmd_binds[] = {
         .name = "/connect",
         .argc = 2, // <hosts> <nick>
         .opt_key =
-        {"-host", "-port", "-tls", "-tls-valid-all", "-pwd", "-nick", "-user", "-real", "-encode",  NULL},
+        {"-port", "-tls", "-tls-valid-all", "-pwd", "-user", "-real", "-encode",  NULL},
         .opt_default_val =
-        {NULL, "6667", NULL, NULL, "Zaidan", "Srain", "Can you can a can?", "UTF-8", NULL},
+        {"6667", NULL, NULL, NULL, "Srain", "Can you can a can?", "UTF-8", NULL},
         .flag = 0,
         .cb = on_command_connect,
     },
@@ -362,7 +362,7 @@ static int on_command_server(Command *cmd, void *user_data){
         if (command_get_opt(cmd, "-tls", NULL)){
             prefs->irc->use_ssl = true;
         }
-        if (command_get_opt(cmd, "-tls-vaild-all", NULL)){
+        if (command_get_opt(cmd, "-tls-valid-all", NULL)){
             prefs->irc->verify_ssl_cert = false;
         }
 
@@ -457,37 +457,31 @@ static int on_command_connect(Command *cmd, void *user_data){
         return SRN_ERR;
     }
 
-    if (!server_prefs_is_valid(prefs)){
+    // if (!server_prefs_is_valid(prefs)){
         // TODO
-        ERR_FR("Not completed ServerPrefs");
-        return SRN_ERR;
-    }
+        // ERR_FR("Not completed ServerPrefs");
+        // return SRN_ERR;
+    // }
 
-    if (command_get_opt(cmd, "-host", &host)){
-        str_assign(&prefs->host, host);
-    }
-    if (command_get_opt(cmd, "-port", &port)){
-        prefs->port = atoi(port);
-    }
-    if (command_get_opt(cmd, "-pwd", &passwd)){
-        str_assign(&prefs->passwd, passwd);
-    }
-    if (command_get_opt(cmd, "-nick", &nick)){
-        str_assign(&prefs->nickname, nick);
-    }
-    if (command_get_opt(cmd, "-user", &user)){
-        str_assign(&prefs->username, user);
-    }
-    if (command_get_opt(cmd, "-real", &real)){
-        str_assign(&prefs->realname, real);
-    }
-    if (command_get_opt(cmd, "-encode", &encoding)){
-        str_assign(&prefs->encoding, encoding);
-    }
+    str_assign(&prefs->host, host);
+    str_assign(&prefs->nickname, nick);
+
+    /* Different with /server, we use default value of command here */
+    command_get_opt(cmd, "-port", &port);
+    prefs->port = atoi(port);
+    command_get_opt(cmd, "-pwd", &passwd);
+    str_assign(&prefs->passwd, passwd);
+    command_get_opt(cmd, "-user", &user);
+    str_assign(&prefs->username, user);
+    command_get_opt(cmd, "-real", &real);
+    str_assign(&prefs->realname, real);
+    command_get_opt(cmd, "-encode", &encoding);
+    str_assign(&prefs->encoding, encoding);
+
     if (command_get_opt(cmd, "-tls", NULL)){
         prefs->irc->use_ssl = true;
     }
-    if (command_get_opt(cmd, "-tls-vaild-all", NULL)){
+    if (command_get_opt(cmd, "-tls-valid-all", NULL)){
         prefs->irc->verify_ssl_cert = false;
     }
 

--- a/src/server/server_cmd.c
+++ b/src/server/server_cmd.c
@@ -57,14 +57,6 @@ static SrnRet on_command_kick(Command *cmd, void *user_data);
 static SrnRet on_command_mode(Command *cmd, void *user_data);
 static SrnRet on_command_list(Command *cmd, void *user_data);
 
-static void on_unknown_cmd(const char *cmd, void *user_data);
-static void on_unknown_opt(Command *cmd, const char *opt, void *user_data);
-static void on_missing_arg(Command *cmd, int narg, void *user_data);
-static void on_missing_opt_val(Command *cmd, const char *opt, void *user_data);
-static void on_too_many_opt(Command *cmd, void *user_data);
-static void on_too_many_arg(Command *cmd, void *user_data);
-static void on_callback_fail(Command *cmd, void *user_data);
-
 CommandBind cmd_binds[] = {
     {
         .name = "/server",
@@ -253,13 +245,6 @@ CommandBind cmd_binds[] = {
 
 static CommandContext cmd_ctx = {
     .binds = cmd_binds,
-    .on_unknown_cmd = on_unknown_cmd,
-    .on_unknown_opt = on_unknown_opt,
-    .on_missing_opt_val = on_missing_opt_val,
-    .on_missing_arg = on_missing_arg,
-    .on_too_many_opt = on_too_many_opt,
-    .on_too_many_arg = on_too_many_arg,
-    .on_callback_fail = on_callback_fail,
 };
 
 static Server *def_srv; // Default server
@@ -859,79 +844,6 @@ static SrnRet on_command_mode(Command *cmd, void *user_data){
 
 static SrnRet on_command_list(Command *cmd, void *user_data){
     return SRN_OK;
-}
-
-/*******************************************************************************
- * Error callbacks
- ******************************************************************************/
-
-static void on_unknown_cmd(const char *cmd, void *user_data){
-    Chat *chat;
-
-    chat = scctx_get_chat(user_data);
-    g_return_if_fail(chat);
-
-    chat_add_error_message_fmt(chat, chat->user->nick,
-            _("No such command: %s"), cmd);
-}
-
-static void on_unknown_opt(Command *cmd, const char *opt, void *user_data){
-    Chat *chat;
-
-    chat = scctx_get_chat(user_data);
-    g_return_if_fail(chat);
-
-    chat_add_error_message_fmt(chat, chat->user->nick,
-            _("No such option: %s"), opt);
-}
-
-static void on_missing_opt_val(Command *cmd, const char *opt, void *user_data){
-    Chat *chat;
-
-    chat = scctx_get_chat(user_data);
-    g_return_if_fail(chat);
-
-    chat_add_error_message_fmt(chat, chat->user->nick,
-            _("Option missing value: %s"), opt);
-}
-
-static void on_missing_arg(Command *cmd, int narg, void *user_data){
-    Chat *chat;
-
-    chat = scctx_get_chat(user_data);
-    g_return_if_fail(chat);
-
-    chat_add_error_message_fmt(chat, chat->user->nick,
-            _("Missing arguments, expecting %d, actually %d"),
-            cmd->bind->argc, narg);
-}
-
-static void on_too_many_opt(Command *cmd, void *user_data){
-    Chat *chat;
-
-    chat = scctx_get_chat(user_data);
-    g_return_if_fail(chat);
-
-    chat_add_error_message_fmt(chat, chat->user->nick, _("Too many options"));
-}
-
-static void on_too_many_arg(Command *cmd, void *user_data){
-    Chat *chat;
-
-    chat = scctx_get_chat(user_data);
-    g_return_if_fail(chat);
-
-    chat_add_error_message_fmt(chat, chat->user->nick, _("Too many arguments"));
-}
-
-static void on_callback_fail(Command *cmd, void *user_data){
-    Chat *chat;
-
-    chat = scctx_get_chat(user_data);
-    g_return_if_fail(chat);
-
-    chat_add_error_message_fmt(chat, chat->user->nick,
-            _("Command failed: %s"), cmd->rawcmd);
 }
 
 /*******************************************************************************

--- a/src/server/server_cmd.c
+++ b/src/server/server_cmd.c
@@ -277,9 +277,9 @@ void server_cmd_init(){
  * @param chat Can be NULL
  * @param cmd
  *
- * @return SRN_ERR or result of `command_proc()`
+ * @return SRN_OK or SRN_ERR or other error
  */
-int server_cmd(Chat *chat, const char *cmd){
+SrnRet server_cmd(Chat *chat, const char *cmd){
     ServerCmdContext scctx;
 
     g_return_val_if_fail(cmd, SRN_ERR);

--- a/src/server/server_irc_event.c
+++ b/src/server/server_irc_event.c
@@ -75,7 +75,7 @@ void server_irc_event_connect(SircSession *sirc, const char *event){
 
     /* Send connection password, you should send it command before sending
      * the NICK/USER combination. */
-    if (strlen(srv->prefs->passwd) > 0){
+    if (srv->prefs->passwd){
         sirc_cmd_pass(srv->irc, srv->prefs->passwd);
     }
     sirc_cmd_nick(srv->irc, user->nick);

--- a/src/server/server_irc_event.c
+++ b/src/server/server_irc_event.c
@@ -73,9 +73,10 @@ void server_irc_event_connect(SircSession *sirc, const char *event){
     chat_add_misc_message_fmt(srv->chat, "", _("Connected to %s(%s:%d)"),
             srv->prefs->name, srv->prefs->host, srv->prefs->port);
 
-    /* Send connection password, you should send it command before sending
-     * the NICK/USER combination. */
-    if (srv->prefs->passwd){
+    /* NOTE: prefs->passwd == "" means no password is set */
+    if (g_strcmp0(srv->prefs->passwd, "") != 0){
+        /* Send connection password, you should send it command before sending
+         * the NICK/USER combination. */
         sirc_cmd_pass(srv->irc, srv->prefs->passwd);
     }
     sirc_cmd_nick(srv->irc, user->nick);

--- a/src/server/server_prefs.c
+++ b/src/server/server_prefs.c
@@ -19,6 +19,7 @@
 
 #include "prefs.h"
 #include "log.h"
+#include "i18n.h"
 
 static GSList *server_prefs_list = NULL;
 
@@ -104,24 +105,58 @@ ServerPrefs* server_prefs_get_prefs(const char *name){
     return NULL;
 }
 
-bool server_prefs_is_valid(ServerPrefs *prefs){
+SrnRet server_prefs_is_valid(ServerPrefs *prefs){
+    const char *fmt = _("Missing field in ServerPrefs: %s");
+
     /* Whether prefs exists in server_prefs_list? */
     if (!prefs || !g_slist_find(server_prefs_list, prefs)){
-            return FALSE;
+        return ERR(_("Invalid ServerPrefs instance"));
      }
 
-    return (prefs->name
-            && prefs->host
-            // && prefs->passwd
-            && prefs->encoding
-            && prefs->nickname
-            && prefs->username
-            && prefs->realname
-            && prefs->part_message
-            && prefs->kick_message
-            && prefs->away_message
-            && prefs->quit_message
-            && prefs->irc);
+    if (!prefs->name) {
+        return ERR(fmt, "name");
+    }
+    if (!prefs->host) {
+        return ERR(fmt, "host");
+    }
+
+    // passwd can be NULL
+    // if (!prefs->passwd) {
+    //    return ERR(fmt, "password");
+    // }
+
+    if (!prefs->encoding) {
+        return ERR(fmt, "encoding");
+    }
+    if (!prefs->nickname) {
+        return ERR(fmt, "nickname");
+    }
+    if (!prefs->username) {
+        return ERR(fmt, "username");
+    }
+    if (!prefs->realname) {
+        return ERR(fmt, "realname");
+    }
+    if (!prefs->part_message) {
+        return ERR(fmt, "part_message");
+    }
+    if (!prefs->kick_message) {
+        return ERR(fmt, "kick_message");
+    }
+    if (!prefs->away_message) {
+        return ERR(fmt, "away_message");
+    }
+    if (!prefs->quit_message) {
+        return ERR(fmt, "quit_message");
+    }
+    if (!prefs->irc) {
+        return ERR(fmt, "irc");
+    }
+    if (!prefs->name) {
+        return ERR(fmt, "name");
+    }
+
+    return sirc_prefs_is_valid(prefs->irc);
 }
 
 void server_prefs_free(ServerPrefs *prefs){

--- a/src/server/server_prefs.c
+++ b/src/server/server_prefs.c
@@ -110,50 +110,50 @@ SrnRet server_prefs_is_valid(ServerPrefs *prefs){
 
     /* Whether prefs exists in server_prefs_list? */
     if (!prefs || !g_slist_find(server_prefs_list, prefs)){
-        return ERR(_("Invalid ServerPrefs instance"));
+        return RET_ERR(_("Invalid ServerPrefs instance"));
      }
 
     if (!prefs->name) {
-        return ERR(fmt, "name");
+        return RET_ERR(fmt, "name");
     }
     if (!prefs->host) {
-        return ERR(fmt, "host");
+        return RET_ERR(fmt, "host");
     }
 
     // passwd can be NULL
     // if (!prefs->passwd) {
-    //    return ERR(fmt, "password");
+    //    return RET_ERR(fmt, "password");
     // }
 
     if (!prefs->encoding) {
-        return ERR(fmt, "encoding");
+        return RET_ERR(fmt, "encoding");
     }
     if (!prefs->nickname) {
-        return ERR(fmt, "nickname");
+        return RET_ERR(fmt, "nickname");
     }
     if (!prefs->username) {
-        return ERR(fmt, "username");
+        return RET_ERR(fmt, "username");
     }
     if (!prefs->realname) {
-        return ERR(fmt, "realname");
+        return RET_ERR(fmt, "realname");
     }
     if (!prefs->part_message) {
-        return ERR(fmt, "part_message");
+        return RET_ERR(fmt, "part_message");
     }
     if (!prefs->kick_message) {
-        return ERR(fmt, "kick_message");
+        return RET_ERR(fmt, "kick_message");
     }
     if (!prefs->away_message) {
-        return ERR(fmt, "away_message");
+        return RET_ERR(fmt, "away_message");
     }
     if (!prefs->quit_message) {
-        return ERR(fmt, "quit_message");
+        return RET_ERR(fmt, "quit_message");
     }
     if (!prefs->irc) {
-        return ERR(fmt, "irc");
+        return RET_ERR(fmt, "irc");
     }
     if (!prefs->name) {
-        return ERR(fmt, "name");
+        return RET_ERR(fmt, "name");
     }
 
     return sirc_prefs_is_valid(prefs->irc);

--- a/src/server/server_prefs.c
+++ b/src/server/server_prefs.c
@@ -87,6 +87,23 @@ ServerPrefs* server_prefs_new(const char *name){
     return prefs;
 }
 
+ServerPrefs* server_prefs_get_by_name(const char *name){
+    GSList *lst;
+    ServerPrefs *prefs;
+
+    lst = server_prefs_list;
+
+    while (lst){
+        prefs = lst->data;
+        if (g_ascii_strcasecmp(prefs->name, name) == 0){
+            return prefs;
+        }
+        lst = g_slist_next(lst);
+    }
+
+    return NULL;
+}
+
 bool server_prefs_is_valid(ServerPrefs *prefs){
     /* Whether prefs exists in server_prefs_list? */
     if (!prefs || !g_slist_find(server_prefs_list, prefs)){

--- a/src/server/server_prefs.c
+++ b/src/server/server_prefs.c
@@ -87,7 +87,7 @@ ServerPrefs* server_prefs_new(const char *name){
     return prefs;
 }
 
-ServerPrefs* server_prefs_get_by_name(const char *name){
+ServerPrefs* server_prefs_get_prefs(const char *name){
     GSList *lst;
     ServerPrefs *prefs;
 

--- a/src/server/server_prefs.c
+++ b/src/server/server_prefs.c
@@ -19,6 +19,7 @@
 
 #include "prefs.h"
 #include "log.h"
+#include "utils.h"
 #include "i18n.h"
 
 static GSList *server_prefs_list = NULL;
@@ -33,7 +34,7 @@ static int server_prefs_list_add(ServerPrefs *prefs){
     lst = server_prefs_list;
     while (lst){
         old_prefs = lst->data;
-        if (strcasecmp(prefs->name, old_prefs->name) == 0){
+        if (g_ascii_strcasecmp(prefs->name, old_prefs->name) == 0){
             return SRN_ERR;
         }
         lst = g_slist_next(lst);
@@ -116,44 +117,49 @@ SrnRet server_prefs_is_valid(ServerPrefs *prefs){
     if (!prefs->name) {
         return RET_ERR(fmt, "name");
     }
+
     if (!prefs->host) {
         return RET_ERR(fmt, "host");
     }
 
-    // passwd can be NULL
-    // if (!prefs->passwd) {
-    //    return RET_ERR(fmt, "password");
-    // }
+    if (!prefs->passwd) {
+        str_assign(&prefs->passwd, "");
+    }
 
     if (!prefs->encoding) {
-        return RET_ERR(fmt, "encoding");
+        str_assign(&prefs->encoding, "UTF-8");
     }
+
     if (!prefs->nickname) {
         return RET_ERR(fmt, "nickname");
     }
+
     if (!prefs->username) {
-        return RET_ERR(fmt, "username");
+        str_assign(&prefs->username, prefs->nickname);
     }
+
     if (!prefs->realname) {
-        return RET_ERR(fmt, "realname");
+        str_assign(&prefs->username, prefs->nickname);
     }
+
     if (!prefs->part_message) {
-        return RET_ERR(fmt, "part_message");
+        str_assign(&prefs->part_message, "");
     }
+
     if (!prefs->kick_message) {
-        return RET_ERR(fmt, "kick_message");
+        str_assign(&prefs->kick_message, "");
     }
+
     if (!prefs->away_message) {
-        return RET_ERR(fmt, "away_message");
+        str_assign(&prefs->away_message, "");
     }
+
     if (!prefs->quit_message) {
-        return RET_ERR(fmt, "quit_message");
+        str_assign(&prefs->quit_message, "");
     }
+
     if (!prefs->irc) {
         return RET_ERR(fmt, "irc");
-    }
-    if (!prefs->name) {
-        return RET_ERR(fmt, "name");
     }
 
     return sirc_prefs_is_valid(prefs->irc);

--- a/src/server/server_prefs.c
+++ b/src/server/server_prefs.c
@@ -112,7 +112,7 @@ bool server_prefs_is_valid(ServerPrefs *prefs){
 
     return (prefs->name
             && prefs->host
-            && prefs->passwd
+            // && prefs->passwd
             && prefs->encoding
             && prefs->nickname
             && prefs->username

--- a/src/server/server_ui_event.c
+++ b/src/server/server_ui_event.c
@@ -111,8 +111,10 @@ void server_ui_event_send(SuiSession *sui, SuiEvent event, const char *params[],
 
     // Command or message?
     if (msg[0] == '/'){
-        if (server_cmd(chat, msg) == SRN_OK){
-            // Nothing to do.
+        SrnRet ret;
+        ret = server_cmd(chat, msg);
+        if (ret != SRN_OK){
+            chat_add_error_message(chat, chat->user->nick, ERRMSG(ret));
         }
     } else {
         chat_add_sent_message(chat, msg);

--- a/src/server/server_ui_event.c
+++ b/src/server/server_ui_event.c
@@ -23,7 +23,7 @@ void server_ui_event_activate(SuiEvent event, const char *params[], int count){
 
     ret = rc_read();
     if (ret != SRN_OK){
-        sui_message_box(_("Error occurred while running commands"), ERRMSG(ret));
+        sui_message_box(_("Error occurred while running commands"), RET_MSG(ret));
     }
 }
 
@@ -114,7 +114,7 @@ void server_ui_event_send(SuiSession *sui, SuiEvent event, const char *params[],
         SrnRet ret;
         ret = server_cmd(chat, msg);
         if (ret != SRN_OK){
-            chat_add_error_message(chat, chat->user->nick, ERRMSG(ret));
+            chat_add_error_message(chat, chat->user->nick, RET_MSG(ret));
         }
     } else {
         chat_add_sent_message(chat, msg);

--- a/src/server/server_ui_event.c
+++ b/src/server/server_ui_event.c
@@ -13,24 +13,18 @@
 #include "rc.h"
 #include "filter.h"
 #include "prefs.h"
+#include "ret.h"
 
 static Server* ctx_get_server(SuiSession *sui);
 static Chat* ctx_get_chat(SuiSession *sui);
 
 void server_ui_event_activate(SuiEvent event, const char *params[], int count){
-    char *errmsg = NULL;
+    SrnRet ret;
 
-    /* We have read prefs in `server_init()`, read it again for reporting error
-     * on a message dialog. */
-    errmsg = prefs_read();
-
-    if (errmsg){
-        sui_message_box(_("Error"), errmsg);
-        g_free(errmsg);
+    ret = rc_read();
+    if (ret != SRN_OK){
+        sui_message_box(_("Error occurred while running commands"), ERRMSG(ret));
     }
-
-    rc_read();
-    // TODO: welcome or command error report
 }
 
 void server_ui_event_connect(SuiEvent event, const char *params[], int count){

--- a/src/server/server_ui_event.c
+++ b/src/server/server_ui_event.c
@@ -22,7 +22,7 @@ void server_ui_event_activate(SuiEvent event, const char *params[], int count){
     SrnRet ret;
 
     ret = rc_read();
-    if (ret != SRN_OK){
+    if (!RET_IS_OK(ret)){
         sui_message_box(_("Error occurred while running commands"), RET_MSG(ret));
     }
 }
@@ -113,8 +113,16 @@ void server_ui_event_send(SuiSession *sui, SuiEvent event, const char *params[],
     if (msg[0] == '/'){
         SrnRet ret;
         ret = server_cmd(chat, msg);
+        // FIXME: chat may be invalid now
+        if (!server_list_is_server(srv)){
+            return;
+        }
         if (ret != SRN_OK){
-            chat_add_error_message(chat, chat->user->nick, RET_MSG(ret));
+            if (RET_IS_OK(ret)){
+                chat_add_misc_message(chat, chat->user->nick, RET_MSG(ret));
+            } else {
+                chat_add_error_message(chat, chat->user->nick, RET_MSG(ret));
+            }
         }
     } else {
         chat_add_sent_message(chat, msg);

--- a/src/server/user.c
+++ b/src/server/user.c
@@ -8,8 +8,8 @@ User *user_new(Chat *chat, const char *nick, const char *username,
 
     g_return_val_if_fail(chat, NULL);
     g_return_val_if_fail(nick, NULL);
-    if (!username) username = "";
-    if (!realname) realname = "";
+    if (!username) username = nick;
+    if (!realname) realname = nick;
 
     user = g_malloc0(sizeof(User));
 

--- a/src/sirc_real/sirc_prefs.c
+++ b/src/sirc_real/sirc_prefs.c
@@ -13,7 +13,7 @@ SircPrefs *sirc_prefs_new(){
 
 SrnRet sirc_prefs_is_valid(SircPrefs *prefs){
     if (!prefs){
-        return ERR(_("Invalid ServerPrefs instance"));
+        return RET_ERR(_("Invalid ServerPrefs instance"));
     }
     return SRN_OK;
 }

--- a/src/sirc_real/sirc_prefs.c
+++ b/src/sirc_real/sirc_prefs.c
@@ -1,17 +1,21 @@
 #include <glib.h>
 
 #include "sirc/sirc.h"
+#include "i18n.h"
 
 SircPrefs *sirc_prefs_new(){
-    SircPrefs *prefs; 
+    SircPrefs *prefs;
 
     prefs = g_malloc0(sizeof(SircPrefs));
 
     return prefs;
 }
 
-bool sirc_prefs_is_valid(SircPrefs *prefs){
-    return prefs;
+SrnRet sirc_prefs_is_valid(SircPrefs *prefs){
+    if (!prefs){
+        return ERR(_("Invalid ServerPrefs instance"));
+    }
+    return SRN_OK;
 }
 
 void sirc_prefs_free(SircPrefs *prefs){

--- a/src/srain.c
+++ b/src/srain.c
@@ -15,6 +15,7 @@
 #include "filter.h"
 #include "decorator.h"
 
+#include "ret.h"
 #include "i18n.h"
 #include "prefs.h"
 #include "plugin.h"
@@ -25,6 +26,7 @@ static void quit();
 int main(int argc, char **argv){
     signal(SIGINT, quit);
 
+    ret_init();
     log_init();
     i18n_init();
     prefs_init();
@@ -48,6 +50,7 @@ static void quit(){
     plugin_finalize();
     server_finalize();
     log_finalize();
+    ret_finalize();
 
     exit(0);
 }

--- a/src/sui_gtk/sui.c
+++ b/src/sui_gtk/sui.c
@@ -483,6 +483,7 @@ void sui_rm_completion(SuiSession *sui, const char *keyword){
 
 void sui_message_box(const char *title, const char *msg){
     GtkMessageDialog *dia;
+    char *markuped_msg;
 
     if (!is_app_run){
         gtk_init(0, NULL);
@@ -498,7 +499,10 @@ void sui_message_box(const char *title, const char *msg){
             );
 
     gtk_window_set_title(GTK_WINDOW(dia), title);
-    gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(dia), msg);
+    // TODO: accpet markuped message
+    markuped_msg = g_markup_escape_text(msg, -1);
+    gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(dia), markuped_msg);
+    g_free(markuped_msg);
 
     /* Without this, message dialog cannot be displayed on the center of screen */
     sui_proc_pending_event();

--- a/src/sui_gtk/sui_prefs.c
+++ b/src/sui_gtk/sui_prefs.c
@@ -1,6 +1,7 @@
 #include <glib.h>
 
 #include "sui/sui.h"
+#include "i18n.h"
 
 SuiAppPrefs *sui_app_prefs_new(){
     SuiAppPrefs *prefs;
@@ -10,10 +11,18 @@ SuiAppPrefs *sui_app_prefs_new(){
     return prefs;
 }
 
-bool sui_app_prefs_is_valid(SuiAppPrefs *prefs){
-    return (prefs
-            && prefs->theme);
+SrnRet sui_app_prefs_is_valid(SuiAppPrefs *prefs){
+    const char *fmt = _("Missing field in SuiAppPrefs: %s");
+
+    if (!prefs){
+        return ERR(_("Invalid SuiAppPrefs instance"));
+    }
+    if (!prefs->theme){
+        return ERR(fmt, "theme");
+    }
+    return SRN_OK;
 }
+
 void sui_app_prefs_free(SuiAppPrefs *prefs){
     g_return_if_fail(prefs);
 
@@ -33,8 +42,11 @@ SuiPrefs *sui_prefs_new(){
     return prefs;
 }
 
-bool sui_prefs_is_valid(SuiPrefs *prefs){
-    return prefs;
+SrnRet sui_prefs_is_valid(SuiPrefs *prefs){
+    if (!prefs){
+        return ERR(_("Invalid SuiPrefs instance"));
+    }
+    return SRN_OK;
 }
 
 void sui_prefs_free(SuiPrefs *prefs){

--- a/src/sui_gtk/sui_prefs.c
+++ b/src/sui_gtk/sui_prefs.c
@@ -15,10 +15,10 @@ SrnRet sui_app_prefs_is_valid(SuiAppPrefs *prefs){
     const char *fmt = _("Missing field in SuiAppPrefs: %s");
 
     if (!prefs){
-        return ERR(_("Invalid SuiAppPrefs instance"));
+        return RET_ERR(_("Invalid SuiAppPrefs instance"));
     }
     if (!prefs->theme){
-        return ERR(fmt, "theme");
+        return RET_ERR(fmt, "theme");
     }
     return SRN_OK;
 }
@@ -44,7 +44,7 @@ SuiPrefs *sui_prefs_new(){
 
 SrnRet sui_prefs_is_valid(SuiPrefs *prefs){
     if (!prefs){
-        return ERR(_("Invalid SuiPrefs instance"));
+        return RET_ERR(_("Invalid SuiPrefs instance"));
     }
     return SRN_OK;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -44,3 +44,10 @@ void time_to_str(time_t time, char *timestr, size_t size, const char *fmt){
 
     timestr[size-1] = '\0';
 }
+
+void str_assign(char **left, const char *right){
+    if (*left) {
+        g_free(*left);
+    }
+    *left = g_strdup(right);
+}


### PR DESCRIPTION
- The srain return value `SrnRet` allows function return a `int` with a message, and both caller and callee don't need to  manage the memory of these messages by themself.
- `/server` command, allow user create a server, specifies various parameters, connect to it and disconnect from it, `/server` also works well with prefs system :-), for the usage of `/server`, refer to `doc/commands.rst`(document not fininised yet)
- TODO: Document of `/server`, let prefs system use `SrnRet`