### PR TITLE
Remove bogus entry from desktop file

### DIFF
--- a/data/Srain.desktop
+++ b/data/Srain.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Version=0.06.3
 Type=Application
 Name=Srain
 GenericName=Srain IRC client


### PR DESCRIPTION
This value refers to the desktop file spec not the application version. It generally isn't needed.

https://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys