### PR TITLE
Add manifest for flatpak-builder

### DIFF
--- a/im.srain.Srain.json
+++ b/im.srain.Srain.json
@@ -1,0 +1,141 @@
+{
+  "app-id": "im.srain.Srain",
+  "runtime": "org.gnome.Platform",
+  "runtime-version": "3.26",
+  "sdk": "org.gnome.Sdk",
+  "command": "srain",
+  "rename-desktop-file": "Srain.desktop",
+  "rename-icon": "srain",
+  "finish-args": [
+    "--device=all",
+    "--filesystem=home:ro",
+    "--socket=pulseaudio",
+    "--socket=x11",
+    "--share=network"
+  ],
+  "modules": [
+    {
+      "name": "libconfig",
+      "buildsystem": "simple",
+      "build-commands": [
+        "./configure --prefix=/app",
+        "make",
+        "make install"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://hyperrealm.github.io/libconfig/dist/libconfig-1.7.2.tar.gz",
+          "sha256": "7c3c7a9c73ff3302084386e96f903eb62ce06953bb1666235fac74363a16fad9"
+        }
+      ]
+    },
+    {
+      "name": "imagemagick",
+      "buildsystem": "simple",
+      "build-commands": [
+        "./configure --prefix=/app",
+        "make",
+        "make install"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://www.imagemagick.org/download/releases/ImageMagick-7.0.6-10.tar.xz",
+          "sha256": "5a9889c87dc351cf4b57ca3ae418c9cdcefc77aaa9a3b16044ae8a4eecf3aeed"
+        }
+      ],
+      "cleanup": [
+        "*"
+      ]
+    },
+    {
+      "name": "requests",
+      "buildsystem": "simple",
+      "build-commands": [
+        "/usr/bin/pip3 --disable-pip-version-check install --prefix=/app --no-deps --verbose ."
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://files.pythonhosted.org/packages/source/r/requests/requests-2.18.4.tar.gz",
+          "sha256": "9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
+        }
+      ]
+    },
+    {
+      "name": "urllib3",
+      "buildsystem": "simple",
+      "build-commands": [
+        "/usr/bin/pip3 --disable-pip-version-check install --prefix=/app --no-deps --verbose ."
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://files.pythonhosted.org/packages/source/u/urllib3/urllib3-1.22.tar.gz",
+          "sha256": "cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
+        }
+      ]
+    },
+    {
+      "name": "chardet",
+      "buildsystem": "simple",
+      "build-commands": [
+        "/usr/bin/pip3 --disable-pip-version-check install --prefix=/app --no-deps --verbose ."
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://files.pythonhosted.org/packages/source/c/chardet/chardet-3.0.4.tar.gz",
+          "sha256": "84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"
+        }
+      ],
+      "cleanup": [
+        "/bin"
+      ]
+    },
+    {
+      "name": "certifi",
+      "buildsystem": "simple",
+      "build-commands": [
+        "/usr/bin/pip3 --disable-pip-version-check install --prefix=/app --no-deps --verbose ."
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://files.pythonhosted.org/packages/source/c/certifi/certifi-2017.7.27.1.tar.gz",
+          "sha256": "40523d2efb60523e113b44602298f0960e900388cf3bb6043f645cf57ea9e3f5"
+        }
+      ]
+    },
+    {
+      "name": "idna",
+      "buildsystem": "simple",
+      "build-commands": [
+        "/usr/bin/pip3 --disable-pip-version-check install --prefix=/app --no-deps --verbose ."
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://files.pythonhosted.org/packages/source/i/idna/idna-2.6.tar.gz",
+          "sha256": "2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"
+        }
+      ]
+    },
+    {
+      "name": "srain",
+      "buildsystem": "simple",
+      "build-commands": [
+        "./configure --prefix=/app --config-dir=/app/etc",
+        "make",
+        "make install"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/SilverRainZ/srain.git"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This allows for building Srain as a distro agnostic flatpak.

At this point it builds and runs fine on my machine, but it needs more testing.

Afterwards it may be a good idea to submit it to flathub so that people can easily find, install and update the builds.