### PR TITLE
Fix icon not appearing in flatpak builds

### DIFF
--- a/contrib/pack/flatpak/latest/im.srain.Srain.json
+++ b/contrib/pack/flatpak/latest/im.srain.Srain.json
@@ -7,6 +7,7 @@
   "rename-desktop-file": "Srain.desktop",
   "rename-appdata-file": "Srain.appdata.xml",
   "rename-icon": "srain",
+  "copy-icon": true,
   "finish-args": [
     "--device=all",
     "--filesystem=home:ro",


### PR DESCRIPTION
The icon was not appearing in the 'about' dialog as intended because it
was getting renamed rather than copied.
There actually was a copy-icon option after all :)