### PR TITLE
Add full appid to appdata file

### DIFF
--- a/data/Srain.appdata.xml
+++ b/data/Srain.appdata.xml
@@ -19,7 +19,7 @@
     </p>
   </description>
 
-  <launchable type="desktop-id">Srain.desktop</launchable>
+  <launchable type="desktop-id">im.srain.Srain.desktop</launchable>
 
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
This is an attempt to workaround issue https://github.com/flathub/im.srain.Srain/issues/1#, which tingping 
believes may be behind the appdata export problems in flathub.